### PR TITLE
fixing logo centering for epub titlepage

### DIFF
--- a/css/generic/titlepage.css
+++ b/css/generic/titlepage.css
@@ -498,6 +498,7 @@ section[data-type="titlepage"] *[class*="TitlepageLogologo"] {
 	float: bottom;
 	width: 100%;
 	height: 0.5in;
+	text-indent: 0;
 	text-align: center;
 	margin-bottom: 0.2in;
 }


### PR DESCRIPTION
Suppress indent for logo in titlepage.css  (successful test on staging)