### PR TITLE
Revising logic to find existing titlepage images

### DIFF
--- a/bookmaker_titlepage.rb
+++ b/bookmaker_titlepage.rb
@@ -224,6 +224,14 @@ elsif !File.file?(titlepagelog) and !File.file?(final_cover)
   gen = true
 end
 
+# now that we've got the logic out of the way,
+# set a default value for the final titlepage, 
+# if no images were found above
+
+if final_cover.empty? or final_cover.nil?
+  final_cover = arch_epubtp
+end
+
 # CSS that will format the final titlepage PDF
 if File.file?("#{Bkmkr::Paths.scripts_dir}/covermaker/css/#{project_dir}/titlepage.css")
   cover_css_file = File.join(pdf_css_dir, project_dir, "titlepage.css")

--- a/bookmaker_titlepage.rb
+++ b/bookmaker_titlepage.rb
@@ -204,8 +204,6 @@ if File.file?(newtitlepage)
   final_cover = newtitlepage
 end
 
-puts final_cover
-
 # set the default switch to generate the titlepage
 gen = false
 
@@ -235,8 +233,6 @@ puts "Titlepage generation: #{gen}"
 if final_cover.empty? or final_cover.nil?
   final_cover = arch_epubtp
 end
-
-puts final_cover
 
 # CSS that will format the final titlepage PDF
 if File.file?("#{Bkmkr::Paths.scripts_dir}/covermaker/css/#{project_dir}/titlepage.css")

--- a/bookmaker_titlepage.rb
+++ b/bookmaker_titlepage.rb
@@ -204,12 +204,14 @@ if File.file?(newtitlepage)
   final_cover = newtitlepage
 end
 
+puts final_cover
+
 # set the default switch to generate the titlepage
 gen = false
 
 # Determine whether or not to generate a titlepage.
 # First check: if an epub titlepage has previously been generated, and no new image has been submitted by the user
-if File.file?(titlepagelog) and final_cover == oldepubtitlepage
+if File.file?(titlepagelog) and !File.file?(newtitlepage)
   gen = true
   Mcmlln::Tools.deleteFile(titlepagelog)
   Mcmlln::Tools.deleteFile(oldtitlepage)
@@ -231,6 +233,8 @@ end
 if final_cover.empty? or final_cover.nil?
   final_cover = arch_epubtp
 end
+
+puts final_cover
 
 # CSS that will format the final titlepage PDF
 if File.file?("#{Bkmkr::Paths.scripts_dir}/covermaker/css/#{project_dir}/titlepage.css")

--- a/bookmaker_titlepage.rb
+++ b/bookmaker_titlepage.rb
@@ -226,6 +226,8 @@ elsif !File.file?(titlepagelog) and !File.file?(final_cover)
   gen = true
 end
 
+puts "Titlepage generation: #{gen}"
+
 # now that we've got the logic out of the way,
 # set a default value for the final titlepage, 
 # if no images were found above


### PR DESCRIPTION
Revising the logic that finds existing or newly submitted titlepages, so that it doesn't falsely find an image when it isn't supposed to. 

Fixes #31 

@mattretzer Matt can you review and approve if it looks ok?