### PR TITLE
hiding header elements on titlepage

### DIFF
--- a/css/generic/titlepage.css
+++ b/css/generic/titlepage.css
@@ -1360,3 +1360,7 @@ section[data-type="preface"] {
   page: front;
 }
 nav[data-type="toc"]{display:none;}
+
+header {
+   display: none;
+}


### PR DESCRIPTION
@nelliemckesson , please review, seems to work fine, tested with Swerve & tor.com titles.  
This is to resolve https://github.com/macmillanpublishers/covermaker/issues/40

I am requesting merge into master b/c since there are no 'header' elements in our existing html it should have no effect on current runs (I ran the testing manuscript through too and was fine)